### PR TITLE
Fix misplaced create.handler example in Module 2

### DIFF
--- a/content-module2.md
+++ b/content-module2.md
@@ -202,33 +202,26 @@ Example of converted handler:
 
 ```ts
 // controllers/users/handlers/create.handler.ts
-import { plainToInstance } from "class-transformer";
-import { validate } from "class-validator";
 import { NextFunction, Request, Response } from "express";
 
-import { UserBody } from "../../../contracts/user.body";
-import { UserView } from "../../../contracts/user.view";
 import { UserStore } from "./user.store";
 
-export const create = async (
+export const create = (
 	req: Request,
 	res: Response,
 	next: NextFunction
 ) => {
-	const transformed = plainToInstance(UserBody, req.body);
-	const validationErrors = await validate(transformed, {
-		skipMissingProperties: false,
-		whitelist: true,
-		forbidNonWhitelisted: true,
-	});
-	if (validationErrors.length) {
-		return next(validationErrors);
+	if (!req.body.name) {
+		return res.status(400).json({ error: "name is required" });
 	}
-	const user = UserStore.add(transformed);
-
-	res.json(plainToInstance(UserView, user));
+	const user = UserStore.add(req.body);
+	res.json(user);
 };
 ```
+
+At this stage we're only converting to TypeScript and adding types. We'll add
+proper input validation and output representation to this handler in the next
+sections.
 
 In `app.ts` you have a property that's less straightforward to type, the `host`.
 This is exposed by express as `Application`.
@@ -368,27 +361,40 @@ class UserBody {
 export { UserBody };
 ```
 
-2. The validation and transformation is already integrated in the `create.handler.ts`
-   example above. The key parts are:
+2. Now integrate the transformation and validation into your `create.handler.ts`.
+   Replace the manual `name` check from the previous section with the transform +
+   validate logic below:
 
 ```ts
-// Import the required functions
+// create.handler.ts
 import { plainToInstance } from "class-transformer";
 import { validate } from "class-validator";
+import { NextFunction, Request, Response } from "express";
 
-// Transform the plain object to an instance of our UserBody class
-const transformed = plainToInstance(UserBody, req.body);
-// Validate the transformed object and retrieve possible errors
-const validationErrors = await validate(transformed, {
-	skipMissingProperties: false,
-	whitelist: true,
-	forbidNonWhitelisted: true,
-});
-// If errors were found, pass them to the express NextFunction
-if (validationErrors.length) {
-	return next(validationErrors);
-}
-const user = UserStore.add(transformed);
+import { UserBody } from "../../../contracts/user.body";
+import { UserStore } from "./user.store";
+
+export const create = async (
+	req: Request,
+	res: Response,
+	next: NextFunction
+) => {
+	// Transform the plain object to an instance of our UserBody class
+	const transformed = plainToInstance(UserBody, req.body);
+	// Validate the transformed object and retrieve possible errors
+	const validationErrors = await validate(transformed, {
+		skipMissingProperties: false,
+		whitelist: true,
+		forbidNonWhitelisted: true,
+	});
+	// If errors were found, pass them to the express NextFunction
+	if (validationErrors.length) {
+		return next(validationErrors);
+	}
+	const user = UserStore.add(transformed);
+
+	res.json(user);
+};
 ```
 
 3. Try it out by using the POST `/api/users` endpoint with both a valid and an
@@ -426,11 +432,44 @@ class UserView {
 export { UserView };
 ```
 
-2. The representation is already integrated in the `create.handler.ts` example above:
+2. Now apply this representation in your `create.handler.ts` by transforming the
+   user object before sending the response. Update the last line of the handler:
 
 ```ts
 // Transform the user object before sending the response
 res.json(plainToInstance(UserView, user));
+```
+
+Your `create.handler.ts` should now look like this:
+
+```ts
+// create.handler.ts
+import { plainToInstance } from "class-transformer";
+import { validate } from "class-validator";
+import { NextFunction, Request, Response } from "express";
+
+import { UserBody } from "../../../contracts/user.body";
+import { UserView } from "../../../contracts/user.view";
+import { UserStore } from "./user.store";
+
+export const create = async (
+	req: Request,
+	res: Response,
+	next: NextFunction
+) => {
+	const transformed = plainToInstance(UserBody, req.body);
+	const validationErrors = await validate(transformed, {
+		skipMissingProperties: false,
+		whitelist: true,
+		forbidNonWhitelisted: true,
+	});
+	if (validationErrors.length) {
+		return next(validationErrors);
+	}
+	const user = UserStore.add(transformed);
+
+	res.json(plainToInstance(UserView, user));
+};
 ```
 
 ## Update handler with validation


### PR DESCRIPTION
## Problem

A learner going through the course noticed that the **"Example of converted handler"** in `content-module2.md` (under *"Add types where needed"*) looked out of place — it appeared to belong later in the course.

They were right that it's misplaced. It's **not** a Module 3 handler (Module 3's `create` is the simplified NestJS version that takes `body: UserBody` directly). It's the *final* Module 2 handler — with manual `class-validator` + `class-transformer` + `UserView` — shown far too early.

The problem: it sits in the pure JavaScript→TypeScript conversion step, but imports four things that haven't been introduced yet at that point:

| Import in the example | Introduced at |
|---|---|
| `class-transformer` / `class-validator` | later (`pnpm add -D ...`) |
| `UserBody` contract | *Explicit validation* section |
| `UserView` contract | *Explicit representation* section |

So a learner following linearly can't reproduce it. The two later sections then said *"already integrated in the example above"* instead of teaching the learner to add the code — same root cause.

## Fix

Build the handler up incrementally, in dependency order:

1. **Add types where needed** → plain type-annotated handler only (Module 1 handler + types), no validation, no view.
2. **Explicit validation** → actively add `plainToInstance(UserBody, …)` + `validate(…)` + `next(validationErrors)`.
3. **Explicit representation** → add `res.json(plainToInstance(UserView, user))` and show the full final handler.

The end-state is identical to what was previously shown early — it's just introduced at the right moment. Nothing is lost.

Left unchanged (already correct): the *Update handler with validation* section (comes after `UserBody`/`UserView` exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)