### PR TITLE
Fix premature UUID in UserView (Module 3)

### DIFF
--- a/content-module3.md
+++ b/content-module3.md
@@ -552,13 +552,13 @@ Make sure your `UserView` contract properly excludes sensitive data:
 ```ts
 // src/contracts/user.view.ts
 import { Exclude, Expose } from "class-transformer";
-import { IsEmail, IsString, IsUUID } from "class-validator";
+import { IsEmail, IsNumber, IsString } from "class-validator";
 
 @Exclude()
 export class UserView {
 	@Expose()
-	@IsUUID()
-	id: string;
+	@IsNumber()
+	id: number;
 
 	@Expose()
 	@IsString()
@@ -1850,6 +1850,35 @@ Key features of this schema:
 -   The `@unique` directive ensures email uniqueness
 -   `createdAt` and `updatedAt` are automatically managed by Prisma
 -   `@@map("users")` maps the model to a "users" table in the database
+
+#### Update the UserView contract
+
+Now that ids are UUID strings instead of incremental numbers, the `UserView`
+contract needs to reflect that. Swap the numeric id (`@IsNumber() id: number`)
+for a UUID string (`@IsUUID() id: string`):
+
+```ts
+// src/contracts/user.view.ts
+import { Exclude, Expose } from "class-transformer";
+import { IsEmail, IsString, IsUUID } from "class-validator";
+
+@Exclude()
+export class UserView {
+	@Expose()
+	@IsUUID()
+	id: string;
+
+	@Expose()
+	@IsString()
+	name: string;
+
+	@Expose()
+	@IsEmail()
+	email: string;
+
+	// password is automatically excluded because it's not @Expose()d
+}
+```
 
 #### Generate Prisma Client
 


### PR DESCRIPTION
## Problem

A course-taker noticed that `UserView` suddenly uses a UUID `id` while the user store is still working with `number`.

The **Response Serialization** section (`content-module3.md`) switches `UserView.id` to a UUID string:

```ts
@IsUUID()
id: string;
```

…but at that point the app is still on the **in-memory `UserStore`**, which is numeric:

- `content-module2.md` — `User.id: number`, ids assigned as `this.users.length` (0, 1, 2, …)
- Module 3 handlers do `const id = Number(idString)`
- Handler-test fixtures use `id: 0`, `id: 1`
- The Module 2 `UserView` was `@IsNumber() id: number`

UUIDs only actually arrive ~1,200 lines later in the **Prisma** section (`id String @id @default(uuid())`). So the material was self-consistent only at the very end and contradictory in between — the view was silently flipped to UUID up front, and the Prisma section never mentioned updating it (because it was already changed).

## Fix

- Keep `UserView.id` numeric (`@IsNumber() id: number`) in the Response Serialization section, matching the Module 2 contract and the in-memory store.
- Add an explicit step in the Prisma section to update `UserView` to `@IsUUID() id: string`, landing the change exactly when the schema switches to `@default(uuid())`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)