### PR TITLE
Fix Prisma CLI commands for pnpm in Module 3

### DIFF
--- a/content-module3.md
+++ b/content-module3.md
@@ -1908,10 +1908,12 @@ pnpm add -D @types/bcryptjs
 
 ### Initialize Prisma
 
-First, we need to initialize Prisma in our project:
+First, we need to initialize Prisma in our project. We just installed Prisma 6
+above, so run that pinned local binary with `pnpm exec` — **not** `pnpm dlx`,
+which would download and run the latest Prisma (7) instead:
 
 ```bash
-npx prisma init
+pnpm exec prisma init
 ```
 
 This creates:
@@ -2081,22 +2083,10 @@ export class UserView {
 
 #### Generate Prisma Client
 
-After defining your schema, generate the Prisma Client:
-
-```bash
-npx prisma generate
-```
-
-This creates type-safe client code based on your schema that you can use in your application.
-
-#### Migrations
-
-Having defined the schema, this now needs to be translated to SQL statements to
-create the accompanying database schema.
-
-Prisma has excellent built-in support for database migrations with automatic generation and version control.
-
-Add the following scripts to your `package.json`:
+From here on we run the Prisma CLI through `package.json` scripts. This keeps us
+on the pinned local Prisma 6: `pnpm dlx prisma ...` would download and run the
+latest Prisma (7) and generate a client that mismatches the `@prisma/client@6`
+we installed. Add these scripts to your `package.json`:
 
 ```json
 {
@@ -2109,7 +2099,22 @@ Add the following scripts to your `package.json`:
 }
 ```
 
-To create and execute a migration:
+After defining your schema, generate the Prisma Client:
+
+```bash
+pnpm db:generate
+```
+
+This creates type-safe client code based on your schema that you can use in your application.
+
+#### Migrations
+
+Having defined the schema, this now needs to be translated to SQL statements to
+create the accompanying database schema.
+
+Prisma has excellent built-in support for database migrations with automatic generation and version control.
+
+We'll use the `db:*` scripts added above. To create and execute a migration:
 
 1. Make sure your database is up and running: `docker compose up -d`
 2. Set the DATABASE_URL environment variable: `export DATABASE_URL="postgresql://root:root@localhost:5432/example?schema=public"`


### PR DESCRIPTION
## What

Fixes the Prisma CLI commands in `content-module3.md` so they work with pnpm and respect the pinned Prisma 6.

Interns hit two issues:
- `npx prisma init` doesn't fit a pnpm workflow.
- `pnpm dlx prisma ...` downloads and runs the **latest** Prisma (7), ignoring the `prisma@6` / `@prisma/client@6` we install a step earlier — producing a client that mismatches the installed runtime.

## Changes

- **`prisma init`** → `pnpm exec prisma init`, so it runs the locally-installed Prisma 6 binary instead of `pnpm dlx`'s latest.
- **`prisma generate`** → run via the `db:generate` package.json script (`pnpm db:generate`), which resolves the local binary.
- Introduced the `db:*` scripts block **once**, in the "Generate Prisma Client" section (before first use), and removed the duplicate block that previously lived in the Migrations section. Migration steps now reference the same scripts.
- Added short notes explaining *why not* `pnpm dlx`, to prevent regressions.

Kept the existing `db:generate` / `db:push` / `db:migrate` / `db:studio` naming.

🤖 Generated with [Claude Code](https://claude.com/claude-code)