### PR TITLE
Fix Module 2/3 docs: test command, DATABASE_URL, tsconfig types

### DIFF
--- a/content-module2.md
+++ b/content-module2.md
@@ -235,7 +235,7 @@ This is exposed by express as `Application`.
 	"build:clean": "rm -rf build && pnpm run build",
 	"start": "node build/server.js",
 	"dev": "ts-node src/server.ts",
-	"test": "mocha -r ts-node/register ./src/tests/**/*.test.ts"
+	"test": "tsc --noEmit && mocha -r ts-node/register ./src/tests/**/*.test.ts"
 },
 ```
 
@@ -595,9 +595,16 @@ pnpm add -D mocha @types/mocha
 
 ```jsonc
 // package.json
-"test": "mocha -r ts-node/register ./src/tests/**/*.test.ts"
+"test": "tsc --noEmit && mocha -r ts-node/register ./src/tests/**/*.test.ts"
 
 ```
+
+The `tsc --noEmit` runs the TypeScript compiler as a type check first (without
+emitting any files); Mocha only runs if there are no type errors. We do this
+because `ts-node/register` falls back to native ESM resolution when it hits a
+compile error, which surfaces as a confusing `ERR_MODULE_NOT_FOUND` instead of
+the actual TypeScript error. Running `tsc --noEmit` first makes the real error
+visible.
 
 When running the command now you'll get a message stating no tests were found
 because we haven't added any tests yet.

--- a/content-module3.md
+++ b/content-module3.md
@@ -59,6 +59,29 @@ We also need to create the NestJS configuration file:
 echo '{"collection": "@nestjs/schematics", "sourceRoot": "src"}' > nest-cli.json
 ```
 
+## Update tsconfig.json
+
+Add `"types": ["node"]` to the `compilerOptions` in your `tsconfig.json`:
+
+```jsonc
+{
+	"compilerOptions": {
+		// ...existing options
+		"types": ["node"]
+	}
+}
+```
+
+By default TypeScript automatically includes **every** `@types/*` package it
+finds in `node_modules/@types` in the global scope. In a NestJS project with
+many (transitive) dependencies that can pull in conflicting or unexpected
+ambient type declarations, which surface as confusing errors when we run
+`tsc --noEmit`. Setting `"types": ["node"]` makes the global scope explicit:
+only `@types/node` (giving you `process`, `Buffer`, etc.) is included globally,
+and everything else is used through explicit imports. That's why our tests
+import their helpers explicitly (`import { describe, it } from "mocha"` and
+`import { expect } from "chai"`).
+
 ## Bootstrap with NestJS
 
 The initialization of the application works different with NestJS than plain Express. NestJS uses a module-based architecture where we bootstrap the application using `NestFactory`.
@@ -1949,7 +1972,24 @@ model User {
 
 ### Environment Configuration
 
-Update your `docker.env` file to include the DATABASE_URL:
+`prisma init` also generated a `.env` file in the root of your project. Prisma
+automatically loads this file and reads `DATABASE_URL` from it. By default it is
+filled in with a placeholder Prisma Postgres URL, which points at a database that
+doesn't exist locally. If you leave it as-is you'll get connection errors (like
+`the URL must start with the protocol ...` or a "service not found" error) when
+you run migrations or start the app.
+
+Replace the generated `DATABASE_URL` in `.env` with the connection string for the
+Postgres container we're running locally — the same value we configured in
+`docker.env`:
+
+```env
+# .env
+DATABASE_URL="postgresql://root:root@localhost:5432/example?schema=public"
+```
+
+Also add the same `DATABASE_URL` to your `docker.env` so all database config
+lives together:
 
 ```env
 POSTGRES_USER=root
@@ -2117,15 +2157,17 @@ Prisma has excellent built-in support for database migrations with automatic gen
 We'll use the `db:*` scripts added above. To create and execute a migration:
 
 1. Make sure your database is up and running: `docker compose up -d`
-2. Set the DATABASE_URL environment variable: `export DATABASE_URL="postgresql://root:root@localhost:5432/example?schema=public"`
-3. For development, you can use: `pnpm db:push` (pushes schema without creating migration files)
-4. For production migrations: `pnpm db:migrate` (creates migration files and applies them)
-5. Generate the Prisma client: `pnpm db:generate`
+2. For development, you can use: `pnpm db:push` (pushes schema without creating migration files)
+3. For production migrations: `pnpm db:migrate` (creates migration files and applies them)
+4. Generate the Prisma client: `pnpm db:generate`
+
+Prisma automatically reads `DATABASE_URL` from the `.env` file we configured
+above, so you don't need to pass it on the command line.
 
 For development, you typically use `prisma db push` which is faster:
 
 ```bash
-DATABASE_URL="postgresql://root:root@localhost:5432/example?schema=public" pnpm db:push
+pnpm db:push
 ```
 
 Now that the schema is pushed, a refresh of your database (`⌘+R` or `ctrl+R`) in


### PR DESCRIPTION
## Summary

Three fixes to the course docs based on issues interns hit while working through Modules 2 and 3.

### 1. Test command now type-checks first (Module 2)
Changed the `test` script to:
```
"test": "tsc --noEmit && mocha -r ts-node/register ./src/tests/**/*.test.ts"
```
When the code has TypeScript errors, `ts-node/register` falls back to native ESM resolution and reports a misleading `ERR_MODULE_NOT_FOUND` instead of the real error. Running `tsc --noEmit` first surfaces the actual TypeScript error, and Mocha only runs when the types are clean. Updated both places the command appears, plus a short explanatory note.

### 2. Prisma `DATABASE_URL` points at the local database (Module 3)
`prisma init` generates a root `.env` whose `DATABASE_URL` is a placeholder **Prisma Postgres** URL. Prisma reads *that* file (not `docker.env`), so leaving it caused connection / "service not found" errors. The **Environment Configuration** section now instructs students to replace the generated `.env` `DATABASE_URL` with the local container URL:
```
DATABASE_URL="postgresql://root:root@localhost:5432/example?schema=public"
```
Also removed the now-redundant inline `export DATABASE_URL=…` / prefixed `pnpm db:push` workarounds in the migrations steps, since Prisma picks the URL up from `.env` automatically.

### 3. `"types": ["node"]` in tsconfig (Module 3)
Added an **Update tsconfig.json** step in Module 3. Without it, TypeScript auto-includes every `@types/*` package globally, which can introduce conflicting ambient declarations that surface as confusing `tsc --noEmit` errors in a NestJS project. Module 3's tests already import mocha/chai explicitly, so restricting the global scope is safe. Module 2 is intentionally left unchanged (its example tests rely on ambient mocha globals).

🤖 Generated with [Claude Code](https://claude.com/claude-code)