### PR TITLE
Standardize on @Serialize for response representation; fix login status

### DIFF
--- a/code/example3/src/app.module.ts
+++ b/code/example3/src/app.module.ts
@@ -1,8 +1,20 @@
 import { Module } from "@nestjs/common";
+import { APP_INTERCEPTOR, Reflector } from "@nestjs/core";
 import { AuthController } from "./controllers/auth/auth.controller";
 import { UserController } from "./controllers/users/user.controller";
+import { TransformInterceptor } from "./interceptors/transform.interceptor";
 
 @Module({
 	controllers: [AuthController, UserController],
+	providers: [
+		// useFactory (rather than useClass) so the Reflector is passed to the
+		// constructor inherited from ClassSerializerInterceptor.
+		{
+			provide: APP_INTERCEPTOR,
+			useFactory: (reflector: Reflector) =>
+				new TransformInterceptor(reflector),
+			inject: [Reflector],
+		},
+	],
 })
 export class AppModule {}

--- a/code/example3/src/controllers/auth/auth.controller.ts
+++ b/code/example3/src/controllers/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body } from "@nestjs/common";
+import { Controller, Post, Body, HttpCode, HttpStatus } from "@nestjs/common";
 import { ApiTags, ApiOperation, ApiResponse } from "@nestjs/swagger";
 
 import { AccessTokenView } from "../../contracts/accessToken.view";
@@ -9,6 +9,7 @@ import { createToken } from "./handlers/login.handler";
 @Controller("auth")
 export class AuthController {
 	@Post("login")
+	@HttpCode(HttpStatus.OK)
 	@ApiOperation({ summary: "Request a new accesstoken" })
 	@ApiResponse({
 		status: 200,

--- a/code/example3/src/controllers/users/user.controller.ts
+++ b/code/example3/src/controllers/users/user.controller.ts
@@ -27,12 +27,14 @@ import { get } from "./handlers/get.handler";
 import { getList } from "./handlers/getList.handler";
 import { update } from "./handlers/update.handler";
 import { JwtAuthGuard } from "../../guards/jwt-auth.guard";
+import { Serialize } from "../../decorators/serialize.decorator";
 
 @ApiTags("users")
 @Controller("users")
 export class UserController {
 	@Post()
 	@HttpCode(HttpStatus.CREATED)
+	@Serialize(UserView)
 	@ApiOperation({ summary: "Create a new user" })
 	@ApiResponse({
 		status: 201,
@@ -47,6 +49,7 @@ export class UserController {
 	@Get()
 	@UseGuards(JwtAuthGuard)
 	@ApiSecurity("x-auth")
+	@Serialize(UserView)
 	@ApiOperation({ summary: "Search users" })
 	@ApiResponse({
 		status: 200,
@@ -60,6 +63,7 @@ export class UserController {
 	@Get(":id")
 	@UseGuards(JwtAuthGuard)
 	@ApiSecurity("x-auth")
+	@Serialize(UserView)
 	@ApiOperation({ summary: "Get a user by id" })
 	@ApiResponse({
 		status: 200,
@@ -74,6 +78,7 @@ export class UserController {
 	@Patch(":id")
 	@UseGuards(JwtAuthGuard)
 	@ApiSecurity("x-auth")
+	@Serialize(UserView)
 	@ApiOperation({ summary: "Update a user" })
 	@ApiResponse({
 		status: 200,

--- a/code/example3/src/decorators/serialize.decorator.ts
+++ b/code/example3/src/decorators/serialize.decorator.ts
@@ -1,0 +1,11 @@
+import { Type } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+
+/**
+ * Marks an endpoint's response to be serialized into the given view contract.
+ *
+ * Usage: `@Serialize(UserView)` on a controller method. The TransformInterceptor
+ * reads this and transforms the handler's return value into the view, stripping
+ * any field that isn't declared on it.
+ */
+export const Serialize = Reflector.createDecorator<Type>();

--- a/code/example3/src/interceptors/transform.interceptor.ts
+++ b/code/example3/src/interceptors/transform.interceptor.ts
@@ -1,0 +1,41 @@
+import {
+	ClassSerializerContextOptions,
+	ClassSerializerInterceptor,
+	ExecutionContext,
+	Injectable,
+} from "@nestjs/common";
+
+import { Serialize } from "../decorators/serialize.decorator";
+
+/**
+ * Serializes every response into the view declared with `@Serialize(View)`.
+ *
+ * It extends the built-in ClassSerializerInterceptor. We only override
+ * `getContextOptions` to resolve the requested view from the route metadata and
+ * put it on `options.type`. The base `intercept()` then runs its normal
+ * serialize pipeline, which does `plainToInstance(View, response)` for both
+ * single objects and arrays. `excludeExtraneousValues` makes it a strict
+ * whitelist: anything not @Expose()d on the view is dropped from the response.
+ *
+ * Handlers can therefore return raw domain objects and stay ignorant of the
+ * representation layer.
+ */
+@Injectable()
+export class TransformInterceptor extends ClassSerializerInterceptor {
+	protected getContextOptions(
+		context: ExecutionContext
+	): ClassSerializerContextOptions | undefined {
+		const view = this.reflector.getAllAndOverride(Serialize, [
+			context.getHandler(),
+			context.getClass(),
+		]);
+
+		// Preserve any options set via the built-in @SerializeOptions().
+		const base = super.getContextOptions(context);
+		if (!view) {
+			return base;
+		}
+
+		return { ...base, type: view, excludeExtraneousValues: true };
+	}
+}

--- a/code/example4/apps/api/src/app.module.ts
+++ b/code/example4/apps/api/src/app.module.ts
@@ -1,8 +1,20 @@
 import { Module } from "@nestjs/common";
+import { APP_INTERCEPTOR, Reflector } from "@nestjs/core";
 import { AuthController } from "./controllers/auth/auth.controller";
 import { UserController } from "./controllers/users/user.controller";
+import { TransformInterceptor } from "./interceptors/transform.interceptor";
 
 @Module({
 	controllers: [AuthController, UserController],
+	providers: [
+		// useFactory (rather than useClass) so the Reflector is passed to the
+		// constructor inherited from ClassSerializerInterceptor.
+		{
+			provide: APP_INTERCEPTOR,
+			useFactory: (reflector: Reflector) =>
+				new TransformInterceptor(reflector),
+			inject: [Reflector],
+		},
+	],
 })
 export class AppModule {}

--- a/code/example4/apps/api/src/controllers/auth/auth.controller.ts
+++ b/code/example4/apps/api/src/controllers/auth/auth.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Post, Body } from "@nestjs/common";
+import { Controller, Post, Body, HttpCode, HttpStatus } from "@nestjs/common";
 import { ApiTags, ApiOperation, ApiResponse } from "@nestjs/swagger";
 
 import { AccessTokenView } from "../../contracts/accessToken.view";
@@ -9,6 +9,7 @@ import { createToken } from "./handlers/login.handler";
 @Controller("auth")
 export class AuthController {
 	@Post("login")
+	@HttpCode(HttpStatus.OK)
 	@ApiOperation({ operationId: "login", summary: "Request a new accesstoken" })
 	@ApiResponse({
 		status: 200,

--- a/code/example4/apps/api/src/controllers/users/handlers/create.handler.ts
+++ b/code/example4/apps/api/src/controllers/users/handlers/create.handler.ts
@@ -1,11 +1,9 @@
-import { plainToInstance } from "class-transformer";
 import bcrypt from "bcryptjs";
 
 import { prisma } from "../../../lib/prisma";
 import { UserBody } from "../../../contracts/user.body";
-import { UserView } from "../../../contracts/user.view";
 
-export const create = async (body: UserBody): Promise<UserView> => {
+export const create = async (body: UserBody) => {
 	const hashedPassword = await bcrypt.hash(body.password, 10);
 
 	const user = await prisma.user.create({
@@ -16,5 +14,5 @@ export const create = async (body: UserBody): Promise<UserView> => {
 		},
 	});
 
-	return plainToInstance(UserView, user, { excludeExtraneousValues: true });
+	return user;
 };

--- a/code/example4/apps/api/src/controllers/users/handlers/get.handler.ts
+++ b/code/example4/apps/api/src/controllers/users/handlers/get.handler.ts
@@ -1,10 +1,8 @@
 import { NotFoundException } from "@nestjs/common";
-import { plainToInstance } from "class-transformer";
 
 import { prisma } from "../../../lib/prisma";
-import { UserView } from "../../../contracts/user.view";
 
-export const get = async (id: string): Promise<UserView> => {
+export const get = async (id: string) => {
 	const user = await prisma.user.findUnique({
 		where: { id },
 	});
@@ -13,5 +11,5 @@ export const get = async (id: string): Promise<UserView> => {
 		throw new NotFoundException("User not found");
 	}
 
-	return plainToInstance(UserView, user, { excludeExtraneousValues: true });
+	return user;
 };

--- a/code/example4/apps/api/src/controllers/users/handlers/getList.handler.ts
+++ b/code/example4/apps/api/src/controllers/users/handlers/getList.handler.ts
@@ -1,9 +1,6 @@
-import { plainToInstance } from "class-transformer";
-
 import { prisma } from "../../../lib/prisma";
-import { UserView } from "../../../contracts/user.view";
 
-export const getList = async (search?: string): Promise<UserView[]> => {
+export const getList = async (search?: string) => {
 	const where = search
 		? {
 				OR: [
@@ -23,10 +20,8 @@ export const getList = async (search?: string): Promise<UserView[]> => {
 		  }
 		: {};
 
-	const users = await prisma.user.findMany({
+	return prisma.user.findMany({
 		where,
 		orderBy: { createdAt: "desc" },
 	});
-
-	return plainToInstance(UserView, users, { excludeExtraneousValues: true });
 };

--- a/code/example4/apps/api/src/controllers/users/handlers/update.handler.ts
+++ b/code/example4/apps/api/src/controllers/users/handlers/update.handler.ts
@@ -1,15 +1,10 @@
 import { NotFoundException } from "@nestjs/common";
-import { plainToInstance } from "class-transformer";
 import bcrypt from "bcryptjs";
 
 import { prisma } from "../../../lib/prisma";
 import { UserBody } from "../../../contracts/user.body";
-import { UserView } from "../../../contracts/user.view";
 
-export const update = async (
-	id: string,
-	body: Partial<UserBody>
-): Promise<UserView> => {
+export const update = async (id: string, body: Partial<UserBody>) => {
 	const existingUser = await prisma.user.findUnique({
 		where: { id },
 	});
@@ -25,10 +20,8 @@ export const update = async (
 		updateData.password = await bcrypt.hash(body.password, 10);
 	}
 
-	const user = await prisma.user.update({
+	return prisma.user.update({
 		where: { id },
 		data: updateData,
 	});
-
-	return plainToInstance(UserView, user, { excludeExtraneousValues: true });
 };

--- a/code/example4/apps/api/src/controllers/users/user.controller.ts
+++ b/code/example4/apps/api/src/controllers/users/user.controller.ts
@@ -27,12 +27,14 @@ import { get } from "./handlers/get.handler";
 import { getList } from "./handlers/getList.handler";
 import { update } from "./handlers/update.handler";
 import { JwtAuthGuard } from "../../guards/jwt-auth.guard";
+import { Serialize } from "../../decorators/serialize.decorator";
 
 @ApiTags("users")
 @Controller("users")
 export class UserController {
 	@Post()
 	@HttpCode(HttpStatus.CREATED)
+	@Serialize(UserView)
 	@ApiOperation({ operationId: "createUser", summary: "Create a new user" })
 	@ApiResponse({
 		status: 201,
@@ -47,6 +49,7 @@ export class UserController {
 	@Get()
 	@UseGuards(JwtAuthGuard)
 	@ApiSecurity("x-auth")
+	@Serialize(UserView)
 	@ApiOperation({ operationId: "listUsers", summary: "Search users" })
 	@ApiResponse({
 		status: 200,
@@ -60,6 +63,7 @@ export class UserController {
 	@Get(":id")
 	@UseGuards(JwtAuthGuard)
 	@ApiSecurity("x-auth")
+	@Serialize(UserView)
 	@ApiOperation({ operationId: "getUser", summary: "Get a user by id" })
 	@ApiResponse({
 		status: 200,
@@ -74,6 +78,7 @@ export class UserController {
 	@Patch(":id")
 	@UseGuards(JwtAuthGuard)
 	@ApiSecurity("x-auth")
+	@Serialize(UserView)
 	@ApiOperation({ operationId: "updateUser", summary: "Update a user" })
 	@ApiResponse({
 		status: 200,

--- a/code/example4/apps/api/src/decorators/serialize.decorator.ts
+++ b/code/example4/apps/api/src/decorators/serialize.decorator.ts
@@ -1,0 +1,11 @@
+import { Type } from "@nestjs/common";
+import { Reflector } from "@nestjs/core";
+
+/**
+ * Marks an endpoint's response to be serialized into the given view contract.
+ *
+ * Usage: `@Serialize(UserView)` on a controller method. The TransformInterceptor
+ * reads this and transforms the handler's return value into the view, stripping
+ * any field that isn't declared on it.
+ */
+export const Serialize = Reflector.createDecorator<Type>();

--- a/code/example4/apps/api/src/interceptors/transform.interceptor.ts
+++ b/code/example4/apps/api/src/interceptors/transform.interceptor.ts
@@ -1,0 +1,41 @@
+import {
+	ClassSerializerContextOptions,
+	ClassSerializerInterceptor,
+	ExecutionContext,
+	Injectable,
+} from "@nestjs/common";
+
+import { Serialize } from "../decorators/serialize.decorator";
+
+/**
+ * Serializes every response into the view declared with `@Serialize(View)`.
+ *
+ * It extends the built-in ClassSerializerInterceptor. We only override
+ * `getContextOptions` to resolve the requested view from the route metadata and
+ * put it on `options.type`. The base `intercept()` then runs its normal
+ * serialize pipeline, which does `plainToInstance(View, response)` for both
+ * single objects and arrays. `excludeExtraneousValues` makes it a strict
+ * whitelist: anything not @Expose()d on the view is dropped from the response.
+ *
+ * Handlers can therefore return raw domain objects and stay ignorant of the
+ * representation layer.
+ */
+@Injectable()
+export class TransformInterceptor extends ClassSerializerInterceptor {
+	protected getContextOptions(
+		context: ExecutionContext
+	): ClassSerializerContextOptions | undefined {
+		const view = this.reflector.getAllAndOverride(Serialize, [
+			context.getHandler(),
+			context.getClass(),
+		]);
+
+		// Preserve any options set via the built-in @SerializeOptions().
+		const base = super.getContextOptions(context);
+		if (!view) {
+			return base;
+		}
+
+		return { ...base, type: view, excludeExtraneousValues: true };
+	}
+}

--- a/content-module3.md
+++ b/content-module3.md
@@ -169,12 +169,7 @@ Converting the code:
     	//     this.router.post("/", adminMiddleware, create);
     	//     this.router.get("/", getList);
     	//     this.router.get("/:id", get);
-    	//     this.router.patch(
-    	//       "/:id",
-    	//       patchValidationMiddleware,
-    	//       update,
-    	//       representationMiddleware
-    	//     );
+    	//     this.router.patch("/:id", update);
     	//     this.router.delete("/:id", deleteUser);
     	//   }
     	async create() {}
@@ -204,8 +199,8 @@ Converting the code:
    be fixing that later.
 
     Most of the commented code is now converted so lets clean it up. Remove all
-    lines except the `post` and `patch`; we'll come back to the middleware used
-    there later.
+    lines except the `post`; we'll come back to the `adminMiddleware` used there
+    later.
 
 The current code:
 
@@ -213,12 +208,6 @@ The current code:
 @Controller("users")
 export class UserController {
 	//     this.router.post("/", adminMiddleware, create);
-	//     this.router.patch(
-	//       "/:id",
-	//       patchValidationMiddleware,
-	//       update,
-	//       representationMiddleware
-	//     );
 	@Post()
 	async create() {
 		return create();
@@ -248,8 +237,8 @@ export class UserController {
 
 #### NestJS body decorator to inject body
 
-Previously we implemented body validation manually in the handler, after that we
-converted it into middleware.  
+Previously we implemented body validation and transformation manually inside the
+handlers with `plainToInstance` and `validate`.  
 Now we will be using NestJS's `@Body()` decorator to inject the body into the
 controller method and have the body automatically transformed and validated.
 
@@ -281,8 +270,8 @@ async update(@Body() body: UserBody) {}
 > includes.
 
 That covers all body validations that previously were done manually. You can
-remove `patchValidationMiddleware` and the manual validation/transformation from
-the `create` handler now.
+remove the manual validation/transformation (the `plainToInstance` and `validate`
+calls) from the `create` and `update` handlers now.
 
 #### NestJS query decorator to inject search param
 
@@ -335,8 +324,7 @@ NestJS uses Guards instead of middleware for authentication and authorization.
 We'll create a proper JWT guard later in the authentication section, but for now
 you can remove the `adminMiddleware` as we'll replace it with a proper guard.
 
-So you can go ahead and remove the remaining commented
-code, `patchValidationMiddleware` and `representationMiddleware`.
+So you can go ahead and remove the remaining commented code now.
 
 ### Converting handlers
 
@@ -349,8 +337,7 @@ Since we are injecting only the items we need now, this becomes a lot easier.
 1. Replace the arguments in each handler with the ones we
    need: `body`, `id`, `query`
     - Also pass the these arguments to the handler from the controller
-2. Return the result instead of calling `res.json(...)` or assigning it
-   to `locals`
+2. Return the result instead of calling `res.json(...)`
 3. Remove the validation/transformation as this has now been abstracted away
    with the decorators
 4. Remove the `next` function calls
@@ -1160,7 +1147,7 @@ export class AccessTokenView {
 <summary>auth.controller.ts</summary>
 
 ```ts
-import { Controller, Post, Body } from "@nestjs/common";
+import { Controller, Post, Body, HttpCode, HttpStatus } from "@nestjs/common";
 
 import { AccessTokenView } from "../../contracts/accessToken.view";
 import { LoginBody } from "../../contracts/login.body";
@@ -1168,7 +1155,10 @@ import { createToken } from "./handlers/login.handler";
 
 @Controller("auth")
 export class AuthController {
+	// A POST defaults to 201 Created in NestJS, but a login isn't creating a
+	// resource — override it to 200 OK (the integration tests expect 200).
 	@Post("login")
+	@HttpCode(HttpStatus.OK)
 	async login(@Body() body: LoginBody): Promise<AccessTokenView> {
 		return createToken(body);
 	}
@@ -1720,7 +1710,9 @@ This will already give you very handy docs. However if you have 100+ endpoints,
 not every endpoint might be very self explanatory.  
 To fix that we can add some descriptions using NestJS Swagger decorators.
 
-Add Swagger decorators to your controllers:
+Add Swagger decorators to your controllers. The `@Serialize(UserView)` and
+`@UseGuards(JwtAuthGuard)` decorators are already there from the earlier sections
+— here we're only layering the `@Api*` documentation decorators on top:
 
 ```ts
 import {
@@ -1729,14 +1721,21 @@ import {
 	ApiResponse,
 	ApiSecurity,
 } from "@nestjs/swagger";
+import { Serialize } from "../../decorators/serialize.decorator";
+import { UserView } from "../../contracts/user.view";
 
 @ApiTags("users")
 @Controller("users")
 export class UserController {
 	@Post()
 	@HttpCode(HttpStatus.CREATED)
+	@Serialize(UserView)
 	@ApiOperation({ summary: "Create a new user" })
-	@ApiResponse({ status: 201, description: "User created successfully" })
+	@ApiResponse({
+		status: 201,
+		description: "User created successfully",
+		type: UserView,
+	})
 	async create(@Body() body: UserBody) {
 		return create(body);
 	}
@@ -1744,13 +1743,49 @@ export class UserController {
 	@Get()
 	@UseGuards(JwtAuthGuard)
 	@ApiSecurity("x-auth")
+	@Serialize(UserView)
 	@ApiOperation({ summary: "Get all users" })
-	@ApiResponse({ status: 200, description: "Users retrieved successfully" })
+	@ApiResponse({
+		status: 200,
+		description: "Users retrieved successfully",
+		type: [UserView],
+	})
 	async getList(@Query() query: SearchQuery) {
 		return getList(query.search);
 	}
 }
 ```
+
+> **Always pass `type` on your success response.** Without it, Swagger records
+> the status code and description but **no response schema**, so `UserView` is
+> never referenced anywhere in the spec and won't be emitted under
+> `components.schemas`. In Module 4 we generate a typed SDK straight from this
+> spec. If the schema isn't there, the `UserView` type simply won't exist in the
+> generated client. Note the array notation `type: [UserView]` for endpoints that
+> return a list.
+
+### `@ApiResponse` vs `@Serialize` — two different jobs
+
+These look related but operate at completely different layers, and **one cannot
+replace the other**:
+
+-   **`@Serialize(UserView)` is a _runtime_ mechanism.** The interceptor actually
+    transforms the object your handler returns and strips anything that isn't
+    `@Expose()`d on the view. That's what keeps the `password` out of the real
+    HTTP response body sent to the client.
+-   **`@ApiResponse({ type: UserView })` is _documentation only_.** It only
+    describes the response in the OpenAPI spec (and therefore in the generated
+    SDK). It does **not** touch the runtime response at all. It's a _claim_ about
+    the shape, not an _enforcement_ of it.
+
+So they are not redundant, and you need both. If you removed `@Serialize` and
+kept only `@ApiResponse`, the spec/SDK would advertise a clean `UserView` while
+the API kept leaking the `password` over the wire — the documentation would be
+lying. `@Serialize` is our single, reusable representation layer: keep it on every
+endpoint that returns a view, and let your handlers return the raw record (as they
+still do once they talk to Prisma in the database section). Don't reach for a
+per-handler `plainToInstance(...)`. The interceptor already does exactly that, in
+one place, for every response.
 
 ## Test out swagger
 

--- a/content-module4.md
+++ b/content-module4.md
@@ -302,28 +302,41 @@ Do this for all endpoints: `login`, `createUser`, `listUsers`, `getUser`,
 ## Honor the view contract
 
 Module 3 taught the four steps of an endpoint, the last being **representation**:
-_transform the handler output to a predefined view contract_. It's worth
-checking your handlers actually do this — if a handler returns the raw Prisma
-record, it leaks fields like the password hash, and the response won't match the
-`UserView` you just documented.
+_transform the handler output to a predefined view contract_. This matters even
+more now: the OpenAPI schema you just documented with `@ApiProperty` promises the
+client a clean `UserView`, so the **actual runtime response must match it**. If a
+handler leaks the raw Prisma record (including the password hash), the generated
+SDK is lying to the frontend.
 
-Map every user response through `UserView` with `class-transformer`. Because
-`UserView` is `@Exclude()` with `@Expose()` on `id`/`name`/`email`, this strips
-everything else:
+You already have the machinery for this from Module 3: the `@Serialize(UserView)`
+decorator plus the global `TransformInterceptor`. Because `UserView` is
+`@Exclude()` with `@Expose()` on `id`/`name`/`email`, the interceptor projects
+every response onto the view and drops everything else (like `password`), for
+both single objects and arrays. So the handlers stay ignorant of the
+representation layer and just return the raw record:
 
 ```ts
 // src/controllers/users/handlers/getList.handler.ts
-import { plainToInstance } from "class-transformer";
-import { UserView } from "../../../contracts/user.view";
-
-export const getList = async (search?: string): Promise<UserView[]> => {
+export const getList = async (search?: string) => {
   // ...build the `where` filter...
-  const users = await prisma.user.findMany({ where, orderBy: { createdAt: "desc" } });
-  return plainToInstance(UserView, users, { excludeExtraneousValues: true });
+  return prisma.user.findMany({ where, orderBy: { createdAt: "desc" } });
 };
 ```
 
-Apply the same `plainToInstance(UserView, …)` in `create`, `get` and `update`.
+Just make sure every user-returning endpoint carries `@Serialize(UserView)` in
+the controller (you added these in Module 3):
+
+```ts
+@Get()
+@Serialize(UserView)
+async getList(@Query() query: SearchQuery): Promise<UserView[]> {
+  return getList(query.search);
+}
+```
+
+The same `@Serialize(UserView)` covers `create`, `get` and `update`. No
+per-handler `plainToInstance(...)` is needed — the interceptor does the
+transformation in one place.
 
 ## Emit the spec to a file
 


### PR DESCRIPTION
## Summary

An intern hit two problems while going through Modules 3–4, which turned out to expose a broader inconsistency in how the course handles **response representation**. This PR makes the whole story consistent on the `@Serialize` approach and fixes two real correctness bugs in the example projects.

### 1. `@ApiResponse` was missing `type` → `UserView` never reached the SDK
In Module 3's Swagger section, `@ApiResponse` was documented with only `status`/`description`. Without `type`, the response schema is never referenced, so `UserView` isn't emitted into `openapi.json` — and the Module 4 SDK generator produces no `UserView` type. Fixed the docs to pass `type: UserView` / `type: [UserView]` (the example code already did this).

### 2. Standardize on `@Serialize`, drop `plainToInstance`
The docs had drifted: Module 3 taught the `@Serialize(UserView)` interceptor, while Module 4 taught per-handler `plainToInstance(UserView, …)`. Now everything uses `@Serialize` as the single, reusable representation layer; handlers return raw records.

### 3. Two real bugs found & fixed in the examples
- **`code/example3` leaked the password hash** — it had *no* runtime response stripping (no `@Serialize`, no interceptor, no `plainToInstance`). Added the `@Serialize` decorator + `TransformInterceptor`, registered globally, and applied `@Serialize(UserView)` to the user endpoints.
- **`login` returned `201` instead of `200`** — a `@Post` defaults to 201, but the docs/tests expect 200. Added `@HttpCode(HttpStatus.OK)`.

## Changes
- **Docs** (`content-module3.md`, `content-module4.md`): `@ApiResponse` `type`; `@ApiResponse` vs `@Serialize` note; `@Serialize` shown in the Swagger snippet; login `@HttpCode`; "Honor the view contract" rewritten to use `@Serialize`.
- **`code/example3`**: add `@Serialize` infra + decorators (fixes password leak); login `@HttpCode(HttpStatus.OK)`.
- **`code/example4`**: add `@Serialize` infra + decorators; remove `plainToInstance` from handlers; login `@HttpCode(HttpStatus.OK)`.

## Verification
- `example3` test suite passes **9/9**, including the previously-failing `should CRUD users` integration test.
- A focused runtime test confirmed `create`/`get`/`list` responses contain only `{id, name, email}` (password + timestamps stripped) and that `login` (no `@Serialize`) still works under the global interceptor.
- Both APIs build clean; regenerated `openapi.json` is **byte-identical**, so the committed SDK is unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)