### PR TITLE
Document db:seed script in Module 3

### DIFF
--- a/content-module3.md
+++ b/content-module3.md
@@ -2094,7 +2094,8 @@ we installed. Add these scripts to your `package.json`:
 		"db:generate": "prisma generate",
 		"db:push": "prisma db push",
 		"db:migrate": "prisma migrate dev",
-		"db:studio": "prisma studio"
+		"db:studio": "prisma studio",
+		"db:seed": "ts-node prisma/seed.ts"
 	}
 }
 ```
@@ -2140,6 +2141,75 @@ Prisma provides safety features:
 -   Migrations are executed in transactions
 -   Migration history is tracked in the `_prisma_migrations` table
 -   You can reset your database: `prisma migrate reset`
+
+#### Seed the database
+
+The schema is in place, but the `users` table is still empty. Rather than
+creating a user through the API every time you reset the database, we'll add a
+**seed script** that populates it with a couple of known users. This is handy
+for local development, and later on in module 4 the frontend expects a seeded
+`john@example.com` account to log in with.
+
+We already registered the `db:seed` script above
+(`"db:seed": "ts-node prisma/seed.ts"`). Now create the script it points to,
+`prisma/seed.ts`:
+
+```ts
+import { PrismaClient } from "@prisma/client";
+import bcrypt from "bcryptjs";
+
+const prisma = new PrismaClient();
+
+async function main() {
+	// Clear existing data
+	await prisma.user.deleteMany();
+
+	// Create initial users
+	const users = await Promise.all([
+		prisma.user.create({
+			data: {
+				name: "John Doe",
+				email: "john@example.com",
+				password: await bcrypt.hash("password123", 10),
+			},
+		}),
+		prisma.user.create({
+			data: {
+				name: "Jane Smith",
+				email: "jane@example.com",
+				password: await bcrypt.hash("password456", 10),
+			},
+		}),
+	]);
+
+	console.log("Seeded users:", users);
+}
+
+main()
+	.then(async () => {
+		await prisma.$disconnect();
+	})
+	.catch(async (e) => {
+		console.error(e);
+		await prisma.$disconnect();
+		process.exit(1);
+	});
+```
+
+A few things worth noting:
+
+-   The passwords are hashed with `bcrypt`, exactly like the `create` handler
+    does, so the seeded users can actually log in through the auth flow.
+-   `deleteMany()` at the top makes the script idempotent: run it as often as
+    you like and you always end up with the same known set of users.
+
+With the database running and the schema pushed, seed it:
+
+```bash
+pnpm db:seed
+```
+
+Refresh TablePlus and you should now see the two users in the `users` table.
 
 ## Updating the handlers
 


### PR DESCRIPTION
## What

Module 3 walks through the full Prisma setup — schema, client, migrations, and the `db:*` scripts — but never mentions **seeding the database**, even though:

- The example code `code/example3` ships both `prisma/seed.ts` and a `"db:seed": "ts-node prisma/seed.ts"` script.
- Module 4 explicitly depends on it: *"Make sure the API's database is running and seeded (from module 3)"* → `pnpm db:seed` (creates `john@example.com` / `password123`, which the frontend logs in with).

A student following Module 3 to the letter would hit a missing `db:seed` script and a missing seeded account the moment they reached Module 4. Reported by a student.

## Changes

- Add `"db:seed": "ts-node prisma/seed.ts"` to the `db:*` scripts block (`ts-node` is already installed in Module 2, so it works out of the box).
- Add a new **"Seed the database"** subsection after Migrations, with the `prisma/seed.ts` file (matching the example code) plus notes on bcrypt-hashed passwords and idempotency, ending with `pnpm db:seed`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)