### PR TITLE
Fix dropped dev script in Module 3 NestJS conversion (breaks Module 4 checkpoint)

### DIFF
--- a/content-module3.md
+++ b/content-module3.md
@@ -789,7 +789,12 @@ Nest.js uses the following commands to start the app, so add/modify them in `pac
 "start": "nest start",
 "start:dev": "nest start --watch",
 "start:debug": "nest start --debug --watch",
+"dev": "nest start --watch",
 ```
+
+We keep the `dev` script that modules 1 and 2 established, so the same
+`pnpm dev` (or `npm run dev`) keeps working here and later when module 4's
+monorepo runs it across every package.
 
 ## Fix tests
 

--- a/content-module4.md
+++ b/content-module4.md
@@ -90,6 +90,11 @@ installs every package together.
 }
 ```
 
+Make sure `apps/api/package.json` still has its `dev` script
+(`"dev": "nest start --watch"` — it came over with the module 3 copy). Turbo's
+`dev` task runs the `dev` script in each package, so the Part 1 checkpoint's
+`pnpm dev` depends on it being there.
+
 ## Create the workspace
 
 At the repo root, tell pnpm which folders are workspace packages:
@@ -223,7 +228,13 @@ pnpm install
 >
 > `pnpm dev` stays running in the foreground — leave it, and open a **second
 > terminal** for any other commands (or stop it with Ctrl-C).
-> The API should boot exactly like it did in module 3. (`apps/api/.env` is
+> Turbo lists the packages in scope, runs `dev` in each, and streams the API's
+> Nest startup logs prefixed with `@node-course/api:dev:`; the process then stays
+> up, waiting. That waiting-in-the-foreground state **is** success — the API
+> should boot exactly like it did in module 3. If instead the command returns
+> immediately with `No tasks were executed as part of this run.`, no package has a
+> `dev` script — check that `apps/api/package.json` still has one (see "Move the
+> API into `apps/api`" above). (`apps/api/.env` is
 > git-ignored — commit an `apps/api/.env.example` with that same line so the next
 > person knows what to create.) You now have a monorepo. On to the interesting part.
 


### PR DESCRIPTION
## Problem

Module 3's **"Update server start commands in package.json"** section lists the NestJS run scripts but omits `dev`. Modules 1 and 2 both establish a `dev` script (`node --watch …` / `ts-node …`), and the reference code `code/example3/package.json` ships `"dev": "nest start --watch"` — so the docs silently break the chain here and diverge from the reference.

This surfaces downstream in **Module 4**: the "Move the API into `apps/api`" section says the package.json changes leave "the rest the same" without mentioning `dev`, and the Part 1 checkpoint runs `pnpm dev` → `turbo run dev`. With no `dev` task, turbo exits immediately with `No tasks were executed as part of this run.` — which reads like a hang.

## Changes

- **Module 3** — add `"dev": "nest start --watch"` to the scripts list (matches `code/example3`), with a one-line note on why the script is kept.
- **Module 4** — add a safety-net note that `apps/api/package.json` must keep its `dev` script for turbo's `dev` task to run.
- **Module 4 checkpoint** — describe the expected turbo output (packages in scope, `@node-course/api:dev:`-prefixed Nest logs, process staying in the foreground) so a reader can tell a successful boot from the silent `No tasks were executed` exit.

## Verification

- `content-module1.md:139` and `content-module2.md:237` both define `dev` — confirmed.
- `code/example3/package.json` has `"dev": "nest start --watch"` — confirmed.
- Module 3 scripts list previously had no `dev` entry — confirmed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)